### PR TITLE
add signature to block header

### DIFF
--- a/messages.md
+++ b/messages.md
@@ -71,7 +71,8 @@ This response has no body definition.
     'parent_root': 'bytes32',
     'state_root': 'bytes32',
     'randao_reveal': 'bytes96',
-    'eth1_data': Eth1Data
+    'eth1_data': Eth1Data,
+    'signature': 'bytes96'
 }
 ```
 


### PR DESCRIPTION
The spec has the signature in the block header too.