### PR TITLE
Adding extra links to BeaconBlockBody

### DIFF
--- a/messages.md
+++ b/messages.md
@@ -105,3 +105,14 @@ This response has no body definition.
     'header_signature:' 'bytes96'
 }
 ```
+
+#### The following definitions are lined to v0.5.0 of the Beacon Chain Spec:
+
+- [ProposerSlashing](https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#proposerslashing)  
+- [AttesterSlashing](https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#attesterslashing)  
+- [Attestation](https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#attestation)  
+- [Deposit](https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#deposit)  
+- [VoluntaryExit](https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#voluntaryexit)  
+- [Transfer](https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#transfer)
+
+


### PR DESCRIPTION
Added links to appropriate sections of the v0.5.0 spec so that the additional complex types in BeaconBlockBody can be looked up.