### PR TITLE
Add a perl implementation of a Hobbit parser

### DIFF
--- a/parsers/build.sh
+++ b/parsers/build.sh
@@ -26,6 +26,10 @@ popd
 #pushd js
 #popd
 
+pushd perl
+    prove -v parser.t
+popd
+
 # N/A
 #pushd php
 #popd

--- a/parsers/perl/Hobbit.pm
+++ b/parsers/perl/Hobbit.pm
@@ -1,0 +1,120 @@
+package Hobbit;
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $opts) = @_;
+    $opts ||= {};
+    my $self = { %$opts };
+    bless($self, $class);
+}
+
+sub parse_request {
+    my ($self, $req) = @_;
+    my ($req_line, $payload) = ($req =~ /(.*?)\n(.*)/s);
+    my @r = split(' ', $req_line);
+    my $headers_len = int $r[5];
+    my $body_len = int $r[6];
+    my $headers = substr $payload, 0, $headers_len;
+    my $body = substr $payload, $headers_len, $body_len;
+    return {
+        proto                => $r[0],
+        version              => $r[1],
+        command              => $r[2],
+        compression          => $r[3],
+        response_compression => [split(',', $r[4])],
+        head_only_indicator  => (defined $r[7] ? $r[7] eq 'H' : 0),
+        headers              => $headers,
+        body                 => $body,
+    }
+}
+
+sub parse_response {
+    my ($self, $res) = @_;
+    my ($res_line, $payload) = ($res =~ /(.*?)\n(.*)/s);
+    my @r = split(' ', $res_line);
+    my $headers_len = int $r[2];
+    my $body_len = int $r[3];
+    my $headers = substr $payload, 0, $headers_len;
+    my $body = substr $payload, $headers_len, $body_len;
+    return {
+        code        => int $r[0],
+        compression => $r[1],
+        headers     => $headers,
+        body        => $body
+    }
+}
+
+sub marshal_request {
+    my ($self, $req) = @_;
+    my $res_compression = join(',', @{ $req->{response_compression} });
+    my $head_only_indicator = $req->{head_only_indicator} ? ' H' : '';
+    my $request_line = sprintf(
+        "%s %s %s %s %s %d %d%s",
+        $req->{proto},
+        $req->{version},
+        $req->{command},
+        $req->{compression},
+        $res_compression,
+        length($req->{headers}),
+        length($req->{body}),
+        $head_only_indicator);
+    my $r = sprintf("%s\n%s%s", $request_line, $req->{headers}, $req->{body});
+    return $r;
+}
+
+sub marshal_response {
+    my ($self, $res) = @_;
+    my $out = sprintf('%s %s %d', $res->{code}, $res->{compression}, length($res->{headers}));
+    if ($res->{body}) {
+        $out .= sprintf(" %d", length($res->{body}));
+    } else {
+        $out .= " 0";
+    }
+    $out .= sprintf("\n%s%s", $res->{headers}, $res->{body});
+    return $out;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Hobbit - a parser for the Hobbit protocol
+
+=head1 SYNOPSIS
+
+    my $hobbit  = Hobbit->new();
+    my $request = $hobbit->parse_request("EWP 0.1 PING none none 0 5\n12345");
+
+=head1 DESCRIPTION
+
+This is a Perl implementation of the Hobbit protocol which is
+a lightweight, multiclient wire protocol for ETH2.0 communications.
+
+=head1 API
+
+=head2 new(%opts)
+
+=head2 parse_request($request_string)
+
+=head2 parse_response($response_string)
+
+=head2 marshal_request($request_hashref)
+
+=head2 marshal_response($response_hashref)
+
+=head1 SEE ALSO
+
+=over 4
+
+=item https://github.com/Whiteblock/hobbits
+
+=back
+
+=head1 AUTHOR
+
+John Beppu (john.beppu@gmail.com)
+
+=cut

--- a/parsers/perl/parser.t
+++ b/parsers/perl/parser.t
@@ -1,0 +1,26 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More tests => 13;
+
+require_ok('./Hobbit.pm');
+
+my $hobbit = Hobbit->new();
+ok($hobbit->isa('Hobbit'), "Hobbit->new() returned a Hobbit parser instance");
+
+my $request = $hobbit->parse_request("EWP 0.1 PING none none 0 5\n12345");
+is($request->{proto}, 'EWP', "proto should be 'EWP'");
+is($request->{version}, '0.1', "version should be '0.1'");
+is($request->{command}, 'PING', "command should be 'PING'");
+is($request->{compression}, 'none', "compression should be 'none'");
+ok(!$request->{head_only_indicator}, "head_only_indicator should be false");
+is($request->{headers}, '', "headers should be an empty string");
+is($request->{body}, '12345', "body should be '12345'");
+
+my $response = $hobbit->parse_response("200 none 4 4\na=16body");
+is($response->{code}, 200, "code should be 200");
+is($response->{compression}, 'none', "compression should be 'none'");
+is($response->{headers}, "a=16", "headers should be 'a=16'");
+is($response->{body}, "body", "body should be 'body'");
+

--- a/parsers/perl/test.pl
+++ b/parsers/perl/test.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use lib './';
+require('Hobbit.pm');
+
+my $hobbit = Hobbit->new();
+
+my $reqres = shift;
+if ($reqres eq 'request') {
+    my $request = do { local $/; <STDIN> };
+    print $hobbit->marshal_request($hobbit->parse_request($request))
+} elsif ($reqres eq 'response') {
+    my $response = do { local $/; <STDIN> };
+    print $hobbit->marshal_response($hobbit->parse_response($response))
+} else {
+    print "invalid request response given\n";
+}

--- a/test/run.py
+++ b/test/run.py
@@ -29,6 +29,7 @@ LANGS = {
      'racket': ['./parsers/racket/test'],
      'scheme':['./parsers/scheme/test'],
      'python':['python', './parsers/python/test.py'],
+     'perl': ['perl', '-I' './parsers/perl', './parsers/perl/test.pl'],
      'go':['go','run','./parsers/go/test.go', './parsers/go/parser.go'],
 }
 

--- a/test/run.py
+++ b/test/run.py
@@ -28,6 +28,7 @@ LANGS = {
     # 'racket': ['./parsers/racket/test'],
     # 'scheme':['./parsers/scheme/test'],
     # 'python':['python', './parsers/python/test.py'],
+    # 'perl': ['perl', '-I' './parsers/perl', './parsers/perl/test.pl'],
     'go':['go','run','./parsers/go/test.go', './parsers/go/parser.go'],
 }
 


### PR DESCRIPTION
@dreamcodez I added the perl command line for running the test command in `test/run.py`, but I left them commented out.  If you uncomment it, It should "just work" :tm: . 