### PR TITLE
Added protocol attribute to request message

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -6,6 +6,7 @@
 
 ```python
 {
+    'protocol': 'string'
     'version': 'string',
     'command': 'string',
     'compression': 'string',


### PR DESCRIPTION
I noticed that in all of the demo implementations that the `request` type has a `protocol` attribute (`EWP`). However, this is not defined in the `request` type defined in `protocol.md` defining the types of `EWP`.